### PR TITLE
Added Download icon inside CTA and remove scroll indicator near download button

### DIFF
--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { ArrowDown } from "lucide-react";
+import { ArrowDown, Download } from "lucide-react";
 
 const Hero = () => {
   const scrollToDownload = () => {
@@ -44,7 +44,10 @@ const Hero = () => {
             onClick={scrollToDownload}
             className="bg-primary hover:bg-primary/90 text-primary-foreground px-8 py-6 text-lg rounded-full glow-primary transition-all hover:scale-105"
           >
-            Download App
+            <span className="flex items-center gap-2">
+              Download App
+              <Download className="w-5 h-5" />
+            </span>
           </Button>
           <Button 
             size="lg"
@@ -54,11 +57,6 @@ const Hero = () => {
           >
             Learn More
           </Button>
-        </div>
-
-        {/* Scroll indicator */}
-        <div className="absolute bottom-8 left-1/2 -translate-x-1/2">
-          <ArrowDown className="w-6 h-6 text-muted-foreground animate-bounce" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
### ✅ Description of Changes

Added a Download icon to the CTA button to make the action more recognizable.

Removed the scroll indicator near the download button for a cleaner interface.

Ensured consistent spacing and alignment with the overall design theme.

Fixes : #4 

### 📸 Before & After

Attached screenshots below to show the visual changes clearly:

Before: 
![WhatsApp Image 2025-10-12 at 17 36 05](https://github.com/user-attachments/assets/3fa65cce-23ee-4aab-b110-8b6d7e585e71)


After: 
<img width="1898" height="894" alt="Screenshot 2025-10-13 181313" src="https://github.com/user-attachments/assets/b2bedefb-7518-4e85-8b66-42fccc446e56" />
